### PR TITLE
Update csp_whitelist.xml

### DIFF
--- a/vendor/magento/module-google-adwords/etc/csp_whitelist.xml
+++ b/vendor/magento/module-google-adwords/etc/csp_whitelist.xml
@@ -11,13 +11,13 @@
         <policy id="script-src">
             <values>
                 <value id="google_ad_services" type="host">www.googleadservices.com</value>
-                <value id="google_analytics" type="host">www.google-analytics.com</value>
+                <value id="google_analytics" type="host">www.google-analytics.com stats.g.doubleclick.net googletagmanager.com www.googletagmanager.com</value>
             </values>
         </policy>
         <policy id="img-src">
             <values>
                 <value id="google_ad_services" type="host">www.googleadservices.com</value>
-                <value id="google_analytics" type="host">www.google-analytics.com</value>
+                <value id="google_analytics" type="host">www.google-analytics.com stats.g.doubleclick.net googletagmanager.com www.googletagmanager.com</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
INFRA-123456: MageMojo CSP fix to whitelist stats.g.doubleclick.net googletagmanager.com www.googletagmanager.com domain